### PR TITLE
Qt6 Port

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -26,4 +26,4 @@ Copyright (c) 2009 Michal Policht
 All rights reserved.
 
 RtMidi: realtime MIDI i/o C++ classes
-Copyright (c) 2003-2014 Gary P. Scavone
+Copyright (c) 2003-2022 Gary P. Scavone

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Please see that page for information on running and using Hairless Midiserial, a
 
 Hairless uses git submodules for library dependencies, so you should use `git clone --recursive URL` when cloning from Github. Alternatively, you can run `git submodule update --init` in order to fetch the submodules to an already-cloned directory.
 
-Hairless Midiserial Bridge release 0.4 was built with Qt 4.7.3. It's also been built and run under Qt 4.7.4 & 4.8.6. Newer Qt version 5.0 will probably require code changes in order to compile and/or run.
+~~Hairless Midiserial Bridge release 0.4 was built with Qt 4.7.3. It's also been built and run under Qt 4.7.4 & 4.8.6. Newer Qt version 5.0 will probably require code changes in order to compile and/or run.~~
+This fork has been ported to Qt 6.3.1 and tested on macOS Monterey on Apple M1 Pro CPU.
+I haven't tested it on Windows and Linux (yet).
 
 The Qt package should contain all dependencies, the graphical IDE "Qt Creator" or the program "qmake" can be used to compile the project hairless-midiserial.pro.
 

--- a/hairless-midiserial.pro
+++ b/hairless-midiserial.pro
@@ -40,7 +40,8 @@ INCLUDEPATH += src/
 # Universal binary for OS X
 
 macx {
-    CONFIG += ppc x86 x86_64 arm64
+    QMAKE_APPLE_DEVICE_ARCHS = x86_64 arm64
+    CONFIG += x86_64 arm64
 }
 
 

--- a/hairless-midiserial.pro
+++ b/hairless-midiserial.pro
@@ -40,7 +40,7 @@ INCLUDEPATH += src/
 # Universal binary for OS X
 
 macx {
-    CONFIG += ppc x86
+    CONFIG += ppc x86 x86_64 arm64
 }
 
 

--- a/hairless-midiserial.pro
+++ b/hairless-midiserial.pro
@@ -4,7 +4,7 @@
 #
 #-------------------------------------------------
 
-QT       += core gui
+QT       += widgets
 
 TARGET = hairless-midiserial
 TEMPLATE = app

--- a/hairless-midiserial.pro
+++ b/hairless-midiserial.pro
@@ -40,7 +40,7 @@ INCLUDEPATH += src/
 # Universal binary for OS X
 
 macx {
-    QMAKE_APPLE_DEVICE_ARCHS = x86_64 arm64
+#    QMAKE_APPLE_DEVICE_ARCHS = x86_64 arm64
     CONFIG += x86_64 arm64
 }
 

--- a/src/BlinkenLight.h
+++ b/src/BlinkenLight.h
@@ -2,7 +2,7 @@
 #define BLINKENLIGHT_H
 
 #include <QObject>
-#include <QLabel>
+#include <QtWidgets/QLabel>
 #include <QTimer>
 
 /*

--- a/src/Bridge.cpp
+++ b/src/Bridge.cpp
@@ -216,7 +216,7 @@ void Bridge::sendMidiMessage() {
   if(msg_data.length() == 0)
     return;
   if(bufferStartsWith(MSG_DEBUG)) {
-      QString debug_msg = QString::fromAscii(msg_data.mid(4, msg_data[3]).data());
+      QString debug_msg = QString::fromLatin1(msg_data.mid(4, msg_data[3]).data());
       emit displayMessage(applyTimeStamp(QString("Serial Says: %1").arg(debug_msg)));
   } else {
       emit debugMessage(applyTimeStamp(QString("Serial In: %1").arg(describeMIDI(msg_data))));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,4 @@
-#include <QtGui/QApplication>
+#include <QtWidgets/QApplication>
 #include "ui/mainwindow.h"
 
 int main(int argc, char *argv[])

--- a/src/ui/aboutdialog.cpp
+++ b/src/ui/aboutdialog.cpp
@@ -7,7 +7,7 @@ AboutDialog::AboutDialog(QWidget *parent) :
 {
     ui->setupUi(this);
 
-    QString text = ui->label_info->text().arg(QString::fromAscii(VERSION)).arg(QString::fromAscii(__DATE__));
+    QString text = ui->label_info->text().arg(QString::fromLatin1(VERSION)).arg(QString::fromLatin1(__DATE__));
     ui->label_info->setText(text);
 }
 

--- a/src/ui/aboutdialog.h
+++ b/src/ui/aboutdialog.h
@@ -1,7 +1,7 @@
 #ifndef ABOUTDIALOG_H
 #define ABOUTDIALOG_H
 
-#include <QDialog>
+#include <QtWidgets/QDialog>
 
 namespace Ui {
     class About;

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -1,11 +1,11 @@
 #ifndef MAINWINDOW_H
 #define MAINWINDOW_H
 
-#include <QMainWindow>
-#include <QComboBox>
-#include <QLabel>
+#include <QtWidgets/QMainWindow>
+#include <QtWidgets/QComboBox>
+#include <QtWidgets/QLabel>
 #include <QTime>
-#include <QMenuBar>
+#include <QtWidgets/QMenuBar>
 #include <QTimer>
 #include "RtMidi.h"
 #include "Bridge.h"

--- a/src/ui/settingsdialog.h
+++ b/src/ui/settingsdialog.h
@@ -1,7 +1,7 @@
 #ifndef SETTINGSDIALOG_H
 #define SETTINGSDIALOG_H
 
-#include <QDialog>
+#include <QTWidgets/QDialog>
 
 namespace Ui {
     class SettingsDialog;


### PR DESCRIPTION
Ported to Qt6 + corrected the architectures for macOS (ppc and x86 are no longer supported in modern OS versions).
Compiles and runs (correctly) on macOS Monterey on Apple Silicon (M1 Pro) - haven't tested it on an Intel-based Mac, Windows nor Linux.

Bumped the rtmidi version, the one that was previously referenced has some issues with driver initialization when no MIDI ports are available (I experienced it first hand), the latest version has this issue fixed (checked - it works).